### PR TITLE
Update google_sheet_update.yml

### DIFF
--- a/.github/workflows/google_sheet_update.yml
+++ b/.github/workflows/google_sheet_update.yml
@@ -7,20 +7,20 @@ jobs:
   update_sheet:
     runs-on: ubuntu-latest
     steps:
-      - name: 'get all added files in the PR'
+      - name: 'get names of all added files in the PR'
         id: 'files'
-        uses: mmagician/get-changed-files@v2
+        uses: Ana06/get-changed-files@v1.2
         env:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Checkout delivery'
+      - name: 'check out delivery file'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      
+
       - name: 'parse milestone'
         id: milestone_parser
-        uses: w3f-community/read-file-action@v2.13
+        uses: w3f/read-file-action@v2.13
         with:
           path: "${{ github.workspace }}/${{ steps.files.outputs.added }}"
 
@@ -29,7 +29,7 @@ jobs:
         uses: actions/github-script@0.9.0
         env:
           link: ${{ steps.milestone_parser.outputs.application_document }}
-        with: 
+        with:
           script: |
             var uri_pattern = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/i;
             let application_doc = process.env.link.match(uri_pattern);
@@ -37,16 +37,18 @@ jobs:
             let application_doc_path_array = application_doc_path.split('/');
             application_doc_path = application_doc_path_array[application_doc_path_array.length - 2] + '/' + application_doc_path_array[application_doc_path_array.length - 1];
             core.setOutput('application_doc_path', application_doc_path);
-      - name: 'Get application commit data'
+            core.setOutput('application_doc_name', application_doc_path_array[application_doc_path_array.length - 1]);
+
+      - name: 'get application commit data'
         if: ${{ success() }}
         uses: octokit/request-action@v2.x
         id: get_application_commit_data
         with:
-          route: "GET /repos/w3f/Open-Grants-Program/commits?path=${{ steps.application_doc_path.outputs.application_doc_path }}"
+          route: "GET /repos/w3f/Grants-Program/commits?path=${{ steps.application_doc_path.outputs.application_doc_path }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Find delivery author in application PRs
+      - name: 'find delivery author in application PRs'
         uses: actions/github-script@0.9.0
         id: match_author
         env:
@@ -62,50 +64,45 @@ jobs:
             }
             core.setFailed(`PR author does not match any author of application.`);
 
+      - name: 'get application file'
+        run: wget "https://raw.githubusercontent.com/w3f/Grants-Program/master/${{ steps.application_doc_path.outputs.application_doc_path }}"
+
+      - name: 'parse application file'
+        id: grant_parser
+        uses: mmagician/read-file-action@v1
+        with:
+          path: "${{ steps.application_doc_path.outputs.application_doc_name }}"
+
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%d/%m/%Y')"
 
-      - name: Get last row
-        if: github.event.pull_request.merged == true
-        id: get_last_row
-        uses: w3f/gsheet.action@v1.1.3
-        with:
-          spreadsheetId: ${{ secrets.SPREADSHEET_ID }}
-          startRow: 450
-          worksheetTitle: "Evaluation"
-        env:
-          GSHEET_CLIENT_EMAIL: ${{ secrets.GSHEET_CLIENT_EMAIL }}
-          GSHEET_PRIVATE_KEY: ${{ secrets.GSHEET_PRIVATE_KEY }}
-
       - name: 'write the data to a gsheet'
         id: 'update_worksheet'
-        uses: jroehl/gsheet.action@v1.0.0 # you can specify '@release' to always have the latest changes
+        uses: jroehl/gsheet.action@v1.1.1 # you can specify '@release' to always have the latest changes
         with:
           spreadsheetId: ${{ secrets.SPREADSHEET_ID }}
           commands: | # list of commands, specified as a valid JSON string. Second entry in 'data' should be project name.
             [
-              { 
-                "command": "appendData", 
-                "args": 
-                { 
+              {
+                "command": "appendData",
+                "args":
+                {
                   "data": [[
-                    "=IFERROR(HYPERLINK(\"#gid=0&range=\" & MATCH(INDIRECT(CONCATENATE(\"B\", TEXT(ROW(), \"#\"))), Legal!$D:$D, 0) & \":\" & MATCH(INDIRECT(CONCATENATE(\"B\", TEXT(ROW(), \"#\"))), Legal!$D:$D, 0), INDEX(Legal!$A$2:$A,MATCH(INDIRECT(CONCATENATE(\"B\", TEXT(ROW(), \"#\"))),Legal!$D$2:$D,0))), \"\")", 
-                    "", 
-                    "${{ steps.milestone_parser.outputs.milestone_number }}", 
+                    "=IFERROR(HYPERLINK(\"#gid=0&range=\" & MATCH(INDIRECT(CONCATENATE(\"B\", TEXT(ROW(), \"#\"))), Legal!$D:$D, 0) & \":\" & MATCH(INDIRECT(CONCATENATE(\"B\", TEXT(ROW(), \"#\"))), Legal!$D:$D, 0), INDEX(Legal!$A$2:$A,MATCH(INDIRECT(CONCATENATE(\"B\", TEXT(ROW(), \"#\"))),Legal!$D$2:$D,0))), \"\")",
+                    "${{ steps.grant_parser.outputs.project_name }}",
+                    "${{ steps.milestone_parser.outputs.milestone_number }}",
                     "",
-                    "Not Yet", 
-                    "=IFERROR(SWITCH(INDIRECT(ADDRESS(ROW(),COLUMN()-1)), "Not Yet", 3, "In Progress", 2, "Asked for Changes", 1, "Final Check", 2, "Done", 0, "Terminated", 0))", 
+                    "Not Yet",
+                    "=IFERROR(SWITCH(INDIRECT(ADDRESS(ROW(),COLUMN()-1)), \"Not Yet\", 3, \"In Progress\", 2, \"Asked for Changes\", 1, \"Final Check\", 2, \"Done\", 0, \"Terminated\", 0))",
                     "=INDEX(Legal!$W$2:$W,MATCH(INDIRECT(CONCATENATE(\"B\", TEXT(ROW(), \"#\"))),Legal!$D$2:$D,0))",
-                    "${{ steps.get_application_pr_data.outputs.application_pr }}",
                     "${{ github.event.pull_request.html_url }}",
-                    "", 
+                    "",
                     "${{ steps.date.outputs.date }}"
-                  ]], 
-                  "worksheetTitle": "Evaluation", 
+                  ]],
+                  "worksheetTitle": "Evaluation",
                   "minCol": 1,
-                  "valueInputOption": "USER_ENTERED",
-                  "minRow": "${{ steps.get_last_row.outputs.lastRow }}"
+                  "valueInputOption": "USER_ENTERED"
                 }
                }
             ]


### PR DESCRIPTION
- `Ana06/get-changed-files@v1.2` is actively maintained and contains both fixes implemented by @mmagician.
- Moved `read-file-action` from `w3f-community` to `w3f` (ideally I would like to rename it to something more accurate like `milestone_delivery_parser` but I don't have the rights).
- Extract project name from application file.
- No need to get last row.
- Fixed wrong format in appended data.