### PR TITLE
Detect maintenance deliveries

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -15,7 +15,9 @@ jobs:
         uses: Ana06/get-changed-files@v2.0.0
         with:
           format: 'json'
-          filter: 'deliveries/*.md'
+          filter: |
+            deliveries/*.md
+            maintenance_deliveries/*.md
           
   check-needs-badge:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_author.yml
+++ b/.github/workflows/check_author.yml
@@ -15,7 +15,9 @@ jobs:
           uses: Ana06/get-changed-files@v2.0.0
           with:
             format: 'json'
-            filter: 'deliveries/*.md'
+            filter: |
+              deliveries/*.md
+              maintenance_deliveries/*.md
             
   check_author:
     runs-on: ubuntu-latest 

--- a/.github/workflows/google_sheet_update.yml
+++ b/.github/workflows/google_sheet_update.yml
@@ -15,7 +15,9 @@ jobs:
         uses: Ana06/get-changed-files@v2.0.0
         with:
           format: 'json'
-          filter: 'deliveries/*.md'
+          filter: |
+            deliveries/*.md
+            maintenance_deliveries/*.md
 
   check-no-success:
     needs: get-delivery-files


### PR DESCRIPTION
Fixes #521

imo

```yaml
filter: |
  deliveries/*.md
  maintenance_deliveries/*.md
```

is a bit cleaner than 

```yaml
filter: '*deliveries/*.md'
```

and the documentation for `get-changed-files` seems to suggest this is possible:

https://github.com/Ana06/get-changed-files#get-all-changed-yml-files-but-exclude-githubyml-files

I also updated the other two workflows, `check-author` and `badges` (wasn't sure about the last one, is it necessary to leave a badge comment on a 1st maintenance grant delivery)?