### PR TITLE
Add wasm-opt-for-rust-maintenance delivery 1

### DIFF
--- a/maintenance_deliveries/wasm-opt-for-rust-maintenance-1.md
+++ b/maintenance_deliveries/wasm-opt-for-rust-maintenance-1.md
@@ -1,0 +1,34 @@
+# Maintenance Delivery :mailbox:
+
+**The [invoice form :pencil:](https://docs.google.com/forms/d/e/1FAIpQLSfmNYaoCgrxyhzgoKQ0ynQvnNRoTmgApz9NrMp-hd8mhIiO0A/viewform) has been filled out correctly for this delivery**  
+
+* **Application Document:** https://github.com/w3f/Grants-Program/blob/master/maintenance/wasm-opt-for-rust.md
+* **Delivery Number:** 1 - December 2022
+* **Delivery Date:** 2023/01/01
+
+
+**Context**
+
+We released version `0.111.0` of the `wasm-opt` crate, upgrading to Binaryen 111,
+and submitted pull requests to `cargo-contract` and `substrate`.
+We made several additional minor fixes.
+
+
+**Deliverables**
+
+Note: a full hourly accounting of work performed is included with the invoice.
+
+| Number | Deliverable | Link | Notes |
+| ------------- | ------------- | ------------- |------------- |
+| 1. | Upgraded to Binaryen 111 | https://github.com/brson/wasm-opt-rs/pull/119 | |
+| 2. | Handled FFI strings more efficiently | https://github.com/brson/wasm-opt-rs/pull/120 | |
+| 3. | Fixed feature selection | https://github.com/brson/wasm-opt-rs/pull/126 | It essentially did not work previously. |
+| 4. | Fixed CI matrix | https://github.com/brson/wasm-opt-rs/pull/125 | We weren't covering some configs we thought we were. |
+| 5. | Rleased `wasm-opt` `0.111.0` | https://crates.io/crates/wasm-opt/0.111.0 | | 
+| 6. | Upgraded `cargo-contract` | https://github.com/paritytech/cargo-contract/pull/888 | |
+| 7. | Upgraded `substrate` | https://github.com/paritytech/substrate/pull/13038 | |
+
+
+**Additional Information**
+
+N/A


### PR DESCRIPTION
This is the December 2022 delivery for [wasm-opt-for-rust maintenance](https://github.com/w3f/Grants-Program/blob/master/maintenance/wasm-opt-for-rust.md).

The language in the original proposal about the delivery schedule was a little confused about whether it was a 4-week delivery or monthly. At the moment I am planning monthly deliveries, but if 4 weeks is desired just let me know.

This month we upgraded wasm-opt to Binaryen 111, made a release, and submitted PRs to upgrade cargo-contract and substrate.

# Milestone Delivery Checklist

- [x] The [milestone-delivery-template.md](https://github.com/w3f/Grant-Milestone-Delivery/blob/master/deliveries/milestone-delivery-template.md) has been copied and updated.
- [x] The [invoice form :pencil:](https://forms.gle/LSRr7PCjBpEbKGh89) has been filled out for this milestone.
- [x] This pull request is being made by the same account as the accepted application.
- [x] In case of acceptance, the payment will be transferred to the BTC/ETH payment address provided in the application.
- [x] The delivery is according to the [Guidelines for Milestone Deliverables](https://github.com/w3f/Grants-Program/blob/master/docs/Support%20Docs/milestone-deliverables-guidelines.md).

https://github.com/w3f/Grants-Program/blob/master/maintenance/wasm-opt-for-rust.md


