### PR TITLE
Add wasm-opt-for-rust-maintenance-2

### DIFF
--- a/maintenance_deliveries/wasm-opt-for-rust-maintenance-2.md
+++ b/maintenance_deliveries/wasm-opt-for-rust-maintenance-2.md
@@ -3,7 +3,7 @@
 **The [invoice form :pencil:](https://docs.google.com/forms/d/e/1FAIpQLSfmNYaoCgrxyhzgoKQ0ynQvnNRoTmgApz9NrMp-hd8mhIiO0A/viewform) has been filled out correctly for this delivery**  
 
 * **Application Document:** https://github.com/w3f/Grants-Program/blob/master/maintenance/wasm-opt-for-rust.md
-* **Delivery Number:** 2 - January 2023
+* **Delivery Number:** 2
 * **Delivery Date:** 2023/02/01
 
 

--- a/maintenance_deliveries/wasm-opt-for-rust-maintenance-2.md
+++ b/maintenance_deliveries/wasm-opt-for-rust-maintenance-2.md
@@ -1,0 +1,38 @@
+# Maintenance Delivery :mailbox:
+
+**The [invoice form :pencil:](https://docs.google.com/forms/d/e/1FAIpQLSfmNYaoCgrxyhzgoKQ0ynQvnNRoTmgApz9NrMp-hd8mhIiO0A/viewform) has been filled out correctly for this delivery**  
+
+* **Application Document:** https://github.com/w3f/Grants-Program/blob/master/maintenance/wasm-opt-for-rust.md
+* **Delivery Number:** 2 - January 2023
+* **Delivery Date:** 2023/02/01
+
+
+**Context**
+
+This month we helped the Substrate developers understand how changes to Binaryen
+111's use of WebAssembly features impact their project; made significant
+progress towards making unicode paths work on Windows; and fixed some minor bugs
+in the wasm-opt-rs bindings.
+
+There were no new releases of Binaryen this month,
+so no work on upgrading wasm-opt-rs.
+Next month we expect to complete the work on unicode paths on Windows,
+and after that there is no significant maintenance work on the horizon
+except for making upgrades for Binaryen releases.
+
+**Deliverables**
+
+Note: a full hourly accounting of work performed is included with the invoice.
+
+| Number | Deliverable | Link | Notes |
+| ------------- | ------------- | ------------- |------------- |
+| 1. | Clarifications about the Binaryen 111 upgrade | https://github.com/paritytech/cargo-contract/pull/891#issuecomment-1372584997 | |
+| 2. | Same | https://github.com/paritytech/substrate/pull/13038#issuecomment-1401099357 | |
+| 3. | Documenting MVP features based on conversations with Substrate devs | https://github.com/brson/wasm-opt-rs/pull/130 | |
+| 4. | Fixed the `--version` flag | https://github.com/brson/wasm-opt-rs/pull/133 |
+| 5. | Status update on unicode paths in Windows | https://github.com/WebAssembly/binaryen/issues/4995#issuecomment-1404314882 | |
+
+
+**Additional Information**
+
+N/A


### PR DESCRIPTION
This month we helped the Substrate developers understand how changes to Binaryen 111's use of WebAssembly features impact their project; made significant progress towards making unicode paths work on Windows; and fixed some minor bugs in the wasm-opt-rs bindings.

There were no new releases of Binaryen this month, so no work on upgrading wasm-opt-rs. Next month we expect to complete the work on unicode paths on Windows, and after that there is no significant maintenance work on the horizon except for making upgrades for Binaryen releases.

# Milestone Delivery Checklist

- [x] The [milestone-delivery-template.md](https://github.com/w3f/Grant-Milestone-Delivery/blob/master/deliveries/milestone-delivery-template.md) has been copied and updated.
- [x] The [invoice form :pencil:](https://forms.gle/LSRr7PCjBpEbKGh89) has been filled out for this milestone.
- [x] This pull request is being made by the same account as the accepted application.
- [x] In case of acceptance, the payment will be transferred to the BTC/ETH payment address provided in the application.
- [x] The delivery is according to the [Guidelines for Milestone Deliverables](https://github.com/w3f/Grants-Program/blob/master/docs/Support%20Docs/milestone-deliverables-guidelines.md).

https://github.com/w3f/Grants-Program/blob/master/maintenance/wasm-opt-for-rust.md
