### PR TITLE
Add wasm-opt-for-rust-maintenance-5

### DIFF
--- a/maintenance_deliveries/wasm-opt-for-rust-maintenance-5.md
+++ b/maintenance_deliveries/wasm-opt-for-rust-maintenance-5.md
@@ -1,0 +1,29 @@
+# Maintenance Delivery :mailbox:
+
+**The [invoice form :pencil:](https://docs.google.com/forms/d/e/1FAIpQLSfmNYaoCgrxyhzgoKQ0ynQvnNRoTmgApz9NrMp-hd8mhIiO0A/viewform) has been filled out correctly for this delivery**  
+
+* **Application Document:** https://github.com/w3f/Grants-Program/blob/master/applications/maintenance/wasm-opt-for-rust.md
+* **Delivery Number:** 5
+* **Delivery Date:** 2023/05/01
+
+
+**Context**
+
+There was little to do last month.
+Our patches to upstream Binaryen to enable Unicode on Windows are still in review,
+with upstream in the process of rewriting them to their preference.
+I responded to a request to support in-memory wasm optimization.
+
+**Deliverables**
+
+Note: a full hourly accounting of work performed is included with the invoice.
+
+| Number | Deliverable | Link | Notes |
+| ------------- | ------------- | ------------- |------------- |
+| 1. | Upstream work on unicode-correctness | https://github.com/WebAssembly/binaryen/pull/5627 | Not authored by me. |
+| 2. | More upstream work on unicode-correctness | https://github.com/WebAssembly/binaryen/pull/5671 | Not authored by me. |
+| 3. | Issue about in-memory optimization | https://github.com/brson/wasm-opt-rs/issues/141 | |
+
+**Additional Information**
+
+N/A


### PR DESCRIPTION
# Milestone Delivery Checklist

- [x] The [milestone-delivery-template.md](https://github.com/w3f/Grant-Milestone-Delivery/blob/master/deliveries/milestone-delivery-template.md) has been copied and updated.
- [x] The [invoice form :pencil:](https://forms.gle/LSRr7PCjBpEbKGh89) has been filled out for this milestone.
- [x] This pull request is being made by the same account as the accepted application.
- [x] In case of acceptance, the payment will be transferred to the BTC/ETH/fiat account provided in the application.
- [x] The delivery is according to the [Guidelines for Milestone Deliverables](https://github.com/w3f/Grants-Program/blob/master/docs/Support%20Docs/milestone-deliverables-guidelines.md).

Link to the application pull request: https://github.com/w3f/Grants-Program/pull/1305

Only 2 hours of work this month.

Our patches to upstream Binaryen to enable unicode on windows are not going to be accepted as-is - the Binaryen authors have begun writing [their own patches](https://github.com/WebAssembly/binaryen/pull/5671) for this purpose.

We have received [a request](https://github.com/brson/wasm-opt-rs/issues/141) on the issue tracker to add support for in-memory operation. It's a feature that makes sense, but which is not supported by Binaryen's underlying file-oriented APIs, so implementing it requires more upstream work. I'm inclined to hack on it, and there's lots of budget since there's nothing else on the table for this project at the moment. If somebody disagrees, let me know.

No new Binaryen releases this month, but it's about time for a new one soon.

Internet Computer [integrated the wasm-opt crate](https://github.com/dfinity/ic-wasm/pull/28) into one of their projects, and Holochain seems to have used it for some purpose. That's in addition to the 2 Polkadot projects and Stellar already using it. GitHub thinks 555 repos have wasm-opt-rs dependencies (mostly substrate forks). So this modest project has had a pretty nice impact.