### PR TITLE
Add wasm-opt-for-rust-maintenance-6

### DIFF
--- a/maintenance_deliveries/wasm-opt-for-rust-maintenance-6.md
+++ b/maintenance_deliveries/wasm-opt-for-rust-maintenance-6.md
@@ -1,0 +1,27 @@
+# Maintenance Delivery :mailbox:
+
+**The [invoice form :pencil:](https://docs.google.com/forms/d/e/1FAIpQLSfmNYaoCgrxyhzgoKQ0ynQvnNRoTmgApz9NrMp-hd8mhIiO0A/viewform) has been filled out correctly for this delivery**  
+
+* **Application Document:** https://github.com/w3f/Grants-Program/blob/master/applications/maintenance/wasm-opt-for-rust.md
+* **Delivery Number:** 6
+* **Delivery Date:** 2023/06/01
+
+
+**Context**
+
+We began work on the binaryen 113 upgrade,
+investigated a report of build errors with GCC 13,
+and discussed adding in-memory APIs with the binaryen authors.
+
+**Deliverables**
+
+Note: a full hourly accounting of work performed is included with the invoice.
+
+| Number | Deliverable | Link | Notes |
+| ------------- | ------------- | ------------- |------------- |
+| 1. | GCC 13 bug report | https://github.com/brson/wasm-opt-rs/issues/143#issuecomment-1535377565 | |
+| 2. | Discussion about in-memory module read/write in binaryen | https://github.com/WebAssembly/binaryen/issues/5736 | |
+
+**Additional Information**
+
+N/A


### PR DESCRIPTION
# Milestone Delivery Checklist

- [x] The [milestone-delivery-template.md](https://github.com/w3f/Grant-Milestone-Delivery/blob/master/deliveries/milestone-delivery-template.md) has been copied and updated.
- [x] The [invoice form :pencil:](https://forms.gle/LSRr7PCjBpEbKGh89) has been filled out for this milestone.
- [x] This pull request is being made by the same account as the accepted application.
- [x] I have disclosed any and all sources of reused code in the submitted repositories and have done my due diligence to meet its license requirements.
- [x] In case of acceptance, the payment will be transferred to the BTC/ETH/fiat account provided in the application.
- [x] The delivery is according to the [Guidelines for Milestone Deliverables](https://grants.web3.foundation/docs/Support%20Docs/milestone-deliverables-guidelines).

Link to the application pull request: https://github.com/w3f/Grants-Program/pull/1305

Again smooth sailing, not a lot of maintenance required.

We have begun work on the upgrade to Binaryen 113.

We [discussed with the binaryen authors](https://github.com/WebAssembly/binaryen/issues/5736) the APIs needed to support in-memory module optimization, and I think we are in agreement about what needs to be done there.

Sadly, Soroban is [disabling wasm-opt by default](https://github.com/stellar/soroban-tools/pull/672) in their tooling - the C++ build is an obstacle for their users because sometimes the local toolchain doesn't work, and because it takes a long time to build. I think this is evidence supporting a rewrite of wasm-opt in pure Rust - the C++ build component is the weak link in this project.

