### PR TITLE
Add wasm-opt-for-rust-maintenance-10

### DIFF
--- a/maintenance_deliveries/wasm-opt-for-rust-maintenance-10.md
+++ b/maintenance_deliveries/wasm-opt-for-rust-maintenance-10.md
@@ -1,0 +1,31 @@
+# Maintenance Delivery :mailbox:
+
+**The [invoice form :pencil:](https://docs.google.com/forms/d/e/1FAIpQLSfmNYaoCgrxyhzgoKQ0ynQvnNRoTmgApz9NrMp-hd8mhIiO0A/viewform) has been filled out correctly for this delivery**  
+
+* **Application Document:** https://github.com/w3f/Grants-Program/blob/master/applications/maintenance/wasm-opt-for-rust.md
+* **Delivery Number:** 10
+* **Delivery Date:** 2023/10/03
+
+
+**Context**
+
+wasm-opt-rs are bindings to Binaryen wasm-opt.
+
+The fixes we made last month caused a link-time regression,
+which we have investigated and posted work-arounds for, but not yet fixed.
+
+We helped finally land a fix for Unicode on Windows in upstream Binaryen.
+
+**Deliverables**
+
+Note: a full hourly accounting of work performed is included with the invoice.
+
+| Number | Deliverable | Link | Notes |
+| ------------- | ------------- | ------------- |------------- |
+| 1. | Final testing of upstream unicode / windows patch | https://github.com/WebAssembly/binaryen/pull/5671#issuecomment-1720071079 | |
+| 2. | Issue about llvm linkage regression | https://github.com/brson/wasm-opt-rs/issues/154#issuecomment-1720135560 | |
+| 3. | More discussion of cc build caching | https://github.com/brson/wasm-opt-rs/issues/148#issuecomment-1720242399 | |
+
+**Additional Information**
+
+N/A


### PR DESCRIPTION
# Milestone Delivery Checklist

- [x] The [milestone-delivery-template.md](https://github.com/w3f/Grant-Milestone-Delivery/blob/master/deliveries/milestone-delivery-template.md) has been copied and updated.
- [x] This pull request is being made by the same account as the accepted application.
- [x] I have disclosed any and all sources of reused code in the submitted repositories and have done my due diligence to meet its license requirements.
- [x] In case of acceptance, an invoice must be submitted and the payment will be transferred to the BTC/ETH/fiat account provided in the application.
- [x] The delivery is according to the [Guidelines for Milestone Deliverables](https://grants.web3.foundation/docs/Support%20Docs/milestone-deliverables-guidelines).

Link to the application pull request: https://github.com/w3f/Grants-Program/pull/1305

We finally landed the long-promised fix for Unicode on Windows in upstream binaryen. It should appear in either release 116 or 117.

The fix we made last month for missing DWARF passes caused an unanticipated link-time regression for projects that also link to LLVM, since the DWARF passes reuse LLVM code, causing conflicting symbols. We have not decided on a fix yet.

Binaryen has released version 115 and 116. We will skip 115, and are working through some problems attempting the 116 upgrade.

There are two months remaining in this contract. I intend to fix the linkage regression, and get wasm-opt updated to the latest revisions of binaryen. I do not expect to have a solution for the cc rebuild times, as I don't have a plan yet that I am confident in, and the demand for it has been relatively subdued.