### PR TITLE
Add wasm-opt-for-rust-maintenance-11

### DIFF
--- a/maintenance_deliveries/wasm-opt-for-rust-maintenance-11.md
+++ b/maintenance_deliveries/wasm-opt-for-rust-maintenance-11.md
@@ -1,0 +1,33 @@
+# Maintenance Delivery :mailbox:
+
+**The [invoice form :pencil:](https://docs.google.com/forms/d/e/1FAIpQLSfmNYaoCgrxyhzgoKQ0ynQvnNRoTmgApz9NrMp-hd8mhIiO0A/viewform) has been filled out correctly for this delivery**  
+
+* **Application Document:** https://github.com/w3f/Grants-Program/blob/master/applications/maintenance/wasm-opt-for-rust.md
+* **Delivery Number:** 11
+* **Delivery Date:** 2023/11/02
+
+
+**Context**
+
+This is a project to maintain Rust bindings to Binaryen's wasm-opt tool.
+
+We fixed the big regression related to DWARF passes by adding an optional "dwarf" feature to the crate, and published 0.114.2.
+We upgraded to binaryen 116 and and published 0.116.0.
+
+
+**Deliverables**
+
+Note: a full hourly accounting of work performed is included with the invoice.
+
+| Number | Deliverable | Link | Notes |
+| ------------- | ------------- | ------------- |------------- |
+| 1. | Fixes for DWARF regression | https://github.com/brson/wasm-opt-rs/pull/156 | |
+| 2. | wasm-opt 0.114.2 | https://crates.io/crates/wasm-opt/0.114.2 | |
+| 3. | Upgrade to binaryen 116 | https://github.com/brson/wasm-opt-rs/pull/155 | |
+| 4. | wasm-opt 0.116.0 | https://crates.io/crates/wasm-opt/0.116.0 | |
+| 5. | Discussion of the DWARF regression | https://github.com/brson/wasm-opt-rs/issues/154#issuecomment-1769743989 | |
+| 6. | Update substrate to 0.116.0 | https://github.com/paritytech/polkadot-sdk/pull/1995 | |
+
+**Additional Information**
+
+N/A


### PR DESCRIPTION
# Milestone Delivery Checklist

- [x] The [milestone-delivery-template.md](https://github.com/w3f/Grant-Milestone-Delivery/blob/master/deliveries/milestone-delivery-template.md) has been copied and updated.
- [x] This pull request is being made by the same account as the accepted application.
- [x] I have disclosed any and all sources of reused code in the submitted repositories and have done my due diligence to meet its license requirements.
- [x] In case of acceptance, an invoice must be submitted and the payment will be transferred to the BTC/ETH/fiat account provided in the application.
- [x] The delivery is according to the [Guidelines for Milestone Deliverables](https://grants.web3.foundation/docs/Support%20Docs/milestone-deliverables-guidelines).

Link to the application pull request: https://github.com/w3f/Grants-Program/pull/1305

---

This month we fixed last month's link-time regression related to DWARF passes by adding an optional "dwarf" crate feature. This is still not optimal: projects that are linking to both the wasm-opt crate and the LLVM source code cannot get DWARF passes in binaryen because of duplicate symbols. At this time I do not have a better fix planned.

This project continues to have problems with long build times, and an issue has been filed suggesting another fix: to download pre-built binaryen archives for common platforms. I have not looked at the issue yet, but it is a potentially viable solution, probably not doable within the remaining time of this contract.

---

November will be the final month of this contract. I would like to discuss with somebody whether we should do this maintenance contract again next year (there are pros and cons); or even whether there are other infrastructural projects the w3f needs help with.

The long-awaited bug fix for unicode on windows - the one big bug I promised to fix in this contract - is fixed upstream but has not made it into a binaryen release yet. Presumably it will be in the next release and I will commit to getting that release into the wasm-opt crate even if the contract expires and is not renewed.
